### PR TITLE
chore(deps): bump uikit from 3.15.17 to 3.15.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-focus-trap": "^1.0.1",
     "ember-modifier": "^3.2.7",
     "ember-toggle": "^9.0.3",
-    "uikit": "^3.15.17"
+    "uikit": "^3.15.25"
   },
   "devDependencies": {
     "@adfinis-sygroup/eslint-config": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12515,10 +12515,10 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
-uikit@^3.15.17:
-  version "3.15.17"
-  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.15.17.tgz#91fb93a41e275458bce845000c079a0a639c4ae2"
-  integrity sha512-WGZosS2P9rShonmAldc1NsW5AyICguY964eVPeuferdbK6gVH1ab+WyGGkE4m5hUPXZ6m/EVUC0EeHkBrHPq0A==
+uikit@^3.15.25:
+  version "3.16.6"
+  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.16.6.tgz#16acb3204830121f94b1d0fe1065930ce63819e8"
+  integrity sha512-xVaCDh9LmCqMOmXfKvZyOyWW5dhym7aVTLNMTiKPnraaACl3szN4OSBTsGzi8DLIN/ntQS6G3Hqi+iEjHop1Uw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- [Release Notes](https://getuikit.com/changelog)

This fixes:
- Fix Dropbar partially closing before opening when switching between Navbar items
- Fix Parallax component updating too late during slide animation in Filter component
- Fix Tooltip component appends to container option, prevents margins in scroll container
- Fix regression in scrollParents function
- Fix prevent background scrolling in Safari
- Fix Scroll component scrolls to elements by name
- Fix Tooltip appends itself to the closest scroll container if within element referenced by container option
- Fix nav in Dropdown component not overriding properties of Nav component
- Fix disable native position sticky in Sticky component if parents overflow is not set to visible
- Fix Drop positioning
- Fix stacking context if using position: sticky in Sticky component
- Fix height calculation for box-sizing: border-box on Accordion content
- Fix error in console if image can't be loaded in Svg component with stroke-animation: true
- Fix scrollIntoView() no longer considers elements with position: clip as scrollable parents
- Fix Slider shows not centered initially with center: true
- Fix positioning of Tooltip and Drop components if target is inline element
- Fix Sticky component resizing on clsBelow class causes stutter
- Fix Sticky component correctly resets on becoming inactive
- Fix detection of finite mode in Slider component with center option enabled

This adds:
- Add Eye and Eye Slash icons
- Add larger gap on larger viewports to Navbar component in UIkit theme
- Add gradient for text background to Text component in UIkit theme
- Add gradient for thumbnav item to Thumbnav component in UIkit theme

This changes:
- Update Lifesaver, Paint Bucket and Video Camera icons to fit outline style
- Improve close icon not overlaying content in Modal component in UIkit theme
- removeAttr no longer accepts a space separated list of attribute names