### PR TITLE
fix(modal): remove non existant cls-panel option

### DIFF
--- a/addon/components/uk-modal.hbs
+++ b/addon/components/uk-modal.hbs
@@ -8,7 +8,6 @@
       stack=@stack
       container=this.containerSelector
       clsPage=@clsPage
-      clsPanel=@clsPanel
       selClose=@selClose
       visible=@visible
       onHide=this.hide

--- a/addon/modifiers/uk-modal.js
+++ b/addon/modifiers/uk-modal.js
@@ -44,7 +44,6 @@ export default class UkModalModifier extends Modifier {
       stack: named.stack ?? false,
       container: named.container,
       clsPage: named.clsPage ?? "uk-modal-page",
-      clsPanel: named.clsPanel ?? "uk-modal-dialog",
       selClose:
         named.selClose ??
         ".uk-modal-close,.uk-modal-close-default,.uk-modal-close-outside,.uk-modal-close-full",

--- a/tests/dummy/app/templates/docs/components/modal.hbs
+++ b/tests/dummy/app/templates/docs/components/modal.hbs
@@ -134,13 +134,6 @@
               <td></td>
             </tr>
             <tr>
-              <td><code>clsPanel</code></td>
-              <td><code>String</code></td>
-              <td><code>"uk-modal-dialog"</code></td>
-              <td>Class of the element to be considered the panel of the modal.</td>
-              <td></td>
-            </tr>
-            <tr>
               <td><code>selClose</code></td>
               <td><code>String</code></td>
               <td>


### PR DESCRIPTION
The `clsPanel` option got renamed to `selPanel` which indicates the real usage of it. It's not a css class which will be added for user specifics, but it is a selector for the modal internally. It won't set any classes on the modal element and should be removed from the ember component arguments as well.

Further information:
* [~~clsPanel~~ -> *selPanel*](https://github.com/uikit/uikit/commit/cd2eda0dcd0700c066563092e90070fedabdee67)
* [it's only a selector, not a custom class definition](https://github.com/uikit/uikit/issues/3219)