### PR TITLE
Use `UkSubnav::Item` instead of `UkSubnav::Link` 

### DIFF
--- a/tests/dummy/app/snippets/subnav.hbs
+++ b/tests/dummy/app/snippets/subnav.hbs
@@ -1,5 +1,5 @@
 <UkSubnav @divider={{true}} as |nav|>
   <nav.item @active={{true}}>Item 1</nav.item>
   <nav.item @disabled={{true}}>Item 2</nav.item>
-  <nav.link @href="/link/to/some/page">Item 3</nav.link>
+  <nav.item @href="/link/to/some/page">Item 3</nav.item>
 </UkSubnav>


### PR DESCRIPTION
- Updated uk-subnav snippet to use `uk-subnav.item` instead of `uk-subnav.link`