### PR TITLE
fix(modal-demo): button alignment

### DIFF
--- a/tests/dummy/app/snippets/modal.hbs
+++ b/tests/dummy/app/snippets/modal.hbs
@@ -9,7 +9,7 @@
   <modal.body>
     <p>Do you really want to proceed?</p>
   </modal.body>
-  <modal.footer @class="uk-text-right">
+  <modal.footer class="uk-text-right">
     <UkButton @color="primary" @label="Ok" @onClick={{this.submit}} />
   </modal.footer>
 </UkModal>


### PR DESCRIPTION
The button alignment isn't working cause the styling is passed as a dynamic parameter, not a normal html attribute.